### PR TITLE
Deleted dependence_deploy variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ Terraform module that deploys cloud-platform's open policy agent. It includes al
 ```hcl
 module "opa" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-opa?ref=0.0.1"
-
-  dependence_deploy = null_resource.deploy
 }
 ```
 
@@ -16,7 +14,6 @@ module "opa" {
 
 | Name                         | Description                                        | Type | Default | Required |
 |------------------------------|----------------------------------------------------|:----:|:-------:|:--------:|
-| dependence_deploy            | Deploy (helm) dependence variable                  | string   |       | yes |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -26,7 +26,6 @@ resource "helm_release" "open_policy_agent" {
 
   depends_on = [
     null_resource.kube_system_ns_label,
-    var.dependence_deploy,
   ]
 
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {})]

--- a/variables.tf
+++ b/variables.tf
@@ -1,4 +1,3 @@
-
 variable "cluster_domain_name" {
   description = "The cluster domain used for externalDNS annotations and certmanager"
 }
@@ -7,8 +6,4 @@ variable "enable_invalid_hostname_policy" {
   description = "Enable wheter to have the OPA policy of invalid hostname enabled"
   default     = false
   type        = bool
-}
-
-variable "dependence_deploy" {
-  description = "Deploy Module dependence in order to be executed (deploy resource is the helm init)"
 }


### PR DESCRIPTION
This variable was needed when we were using Helm 2, it was the way to tell Helm Chart inside our terraform modules to wait for tiller before getting installed.

Now we are using Helm 3 and there is not tiller in the clusters.