### PR TITLE
Opa policies for modsec

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -184,6 +184,90 @@ resource "kubernetes_config_map" "policy_pod_toleration_withnullkey" {
   }
 }
 
+resource "kubernetes_config_map" "policy_ingress_nginx_class_modsec" {
+  metadata {
+    name      = "policy-ingress-nginx-class-modsec"
+    namespace = helm_release.open_policy_agent.namespace
+
+    labels = {
+      "openpolicyagent.org/policy" = "rego"
+    }
+  }
+
+  data = {
+    main = file(
+      "${path.module}/resources/policies/ingress_modsec_nginx_class.rego",
+    )
+  }
+
+  lifecycle {
+    ignore_changes = [metadata.0.annotations]
+  }
+}
+
+resource "kubernetes_config_map" "policy_ingress_no_nginx_class_modsec" {
+  metadata {
+    name      = "policy-ingress-no-nginx-class-modsec"
+    namespace = helm_release.open_policy_agent.namespace
+
+    labels = {
+      "openpolicyagent.org/policy" = "rego"
+    }
+  }
+
+  data = {
+    main = file(
+      "${path.module}/resources/policies/ingress_modsec_no_nginx_class.rego",
+    )
+  }
+
+  lifecycle {
+    ignore_changes = [metadata.0.annotations]
+  }
+}
+
+resource "kubernetes_config_map" "policy_ingress_nginx_class_modsec_snippet" {
+  metadata {
+    name      = "policy-ingress-nginx-class-modsec-snippet"
+    namespace = helm_release.open_policy_agent.namespace
+
+    labels = {
+      "openpolicyagent.org/policy" = "rego"
+    }
+  }
+
+  data = {
+    main = file(
+      "${path.module}/resources/policies/ingress_modsec_snippet_nginx_class.rego",
+    )
+  }
+
+  lifecycle {
+    ignore_changes = [metadata.0.annotations]
+  }
+}
+
+resource "kubernetes_config_map" "policy_ingress_no_nginx_class_modsec_snippet" {
+  metadata {
+    name      = "policy-ingress-no-nginx-class-modsec-snippet"
+    namespace = helm_release.open_policy_agent.namespace
+
+    labels = {
+      "openpolicyagent.org/policy" = "rego"
+    }
+  }
+
+  data = {
+    main = file(
+      "${path.module}/resources/policies/ingress_modsec_snippet_no_nginx_class.rego",
+    )
+  }
+
+  lifecycle {
+    ignore_changes = [metadata.0.annotations]
+  }
+}
+
 ##################
 # Resource Quota #
 ##################

--- a/main.tf
+++ b/main.tf
@@ -45,9 +45,23 @@ resource "null_resource" "kube_system_ns_label" {
   }
 }
 
-resource "kubernetes_config_map" "policy_default" {
+resource "kubernetes_config_map" "policies_opa" {
+
+  for_each = {
+    policy-default                               = "main",
+    policy-cloud-platform-admission              = "cloud_platform_admission",
+    policy-ingress-clash                         = "ingress_clash",
+    policy-service-type                          = "service_type",
+    policy-pod-toleration-withkey                = "pod_toleration_withkey",
+    policy-pod-toleration-withnullkey            = "pod_toleration_withnullkey",
+    policy-ingress-nginx-class-modsec            = "ingress_modsec_nginx_class",
+    policy-ingress-no-nginx-class-modsec         = "ingress_modsec_no_nginx_class",
+    policy-ingress-nginx-class-modsec-snippet    = "ingress_modsec_snippet_nginx_class",
+    policy-ingress-no-nginx-class-modsec-snippet = "ingress_modsec_snippet_no_nginx_class",
+  }
+
   metadata {
-    name      = "policy-default"
+    name      = each.key
     namespace = helm_release.open_policy_agent.namespace
 
     labels = {
@@ -56,7 +70,7 @@ resource "kubernetes_config_map" "policy_default" {
   }
 
   data = {
-    main = file("${path.module}/resources/policies/main.rego")
+    main = file("${path.module}/resources/policies/${each.value}.rego")
   }
 
   lifecycle {
@@ -78,191 +92,6 @@ resource "kubernetes_config_map" "valid_host" {
       cluster_domain_name = "*.${var.cluster_domain_name}"
     })
   }
-  lifecycle {
-    ignore_changes = [metadata.0.annotations]
-  }
-}
-
-resource "kubernetes_config_map" "policy_cloud_platform_admission" {
-  metadata {
-    name      = "policy-cloud-platform-admission"
-    namespace = helm_release.open_policy_agent.namespace
-
-    labels = {
-      "openpolicyagent.org/policy" = "rego"
-    }
-  }
-
-  data = {
-    main = file(
-      "${path.module}/resources/policies/cloud_platform_admission.rego",
-    )
-  }
-
-  lifecycle {
-    ignore_changes = [metadata.0.annotations]
-  }
-}
-
-resource "kubernetes_config_map" "policy_ingress_clash" {
-  metadata {
-    name      = "policy-ingress-clash"
-    namespace = helm_release.open_policy_agent.namespace
-
-    labels = {
-      "openpolicyagent.org/policy" = "rego"
-    }
-  }
-
-  data = {
-    main = file("${path.module}/resources/policies/ingress_clash.rego")
-  }
-
-  lifecycle {
-    ignore_changes = [metadata.0.annotations]
-  }
-}
-
-resource "kubernetes_config_map" "policy_service_type" {
-  metadata {
-    name      = "policy-service-type"
-    namespace = helm_release.open_policy_agent.namespace
-
-    labels = {
-      "openpolicyagent.org/policy" = "rego"
-    }
-  }
-
-  data = {
-    main = file("${path.module}/resources/policies/service_type.rego")
-  }
-
-  lifecycle {
-    ignore_changes = [metadata.0.annotations]
-  }
-}
-
-resource "kubernetes_config_map" "policy_pod_toleration_withkey" {
-  metadata {
-    name      = "policy-pod-toleration-withkey"
-    namespace = helm_release.open_policy_agent.namespace
-
-    labels = {
-      "openpolicyagent.org/policy" = "rego"
-    }
-  }
-
-  data = {
-    main = file(
-      "${path.module}/resources/policies/pod_toleration_withkey.rego",
-    )
-  }
-
-  lifecycle {
-    ignore_changes = [metadata.0.annotations]
-  }
-}
-
-resource "kubernetes_config_map" "policy_pod_toleration_withnullkey" {
-  metadata {
-    name      = "policy-pod-toleration-withnullkey"
-    namespace = helm_release.open_policy_agent.namespace
-
-    labels = {
-      "openpolicyagent.org/policy" = "rego"
-    }
-  }
-
-  data = {
-    main = file(
-      "${path.module}/resources/policies/pod_toleration_withnullkey.rego",
-    )
-  }
-
-  lifecycle {
-    ignore_changes = [metadata.0.annotations]
-  }
-}
-
-resource "kubernetes_config_map" "policy_ingress_nginx_class_modsec" {
-  metadata {
-    name      = "policy-ingress-nginx-class-modsec"
-    namespace = helm_release.open_policy_agent.namespace
-
-    labels = {
-      "openpolicyagent.org/policy" = "rego"
-    }
-  }
-
-  data = {
-    main = file(
-      "${path.module}/resources/policies/ingress_modsec_nginx_class.rego",
-    )
-  }
-
-  lifecycle {
-    ignore_changes = [metadata.0.annotations]
-  }
-}
-
-resource "kubernetes_config_map" "policy_ingress_no_nginx_class_modsec" {
-  metadata {
-    name      = "policy-ingress-no-nginx-class-modsec"
-    namespace = helm_release.open_policy_agent.namespace
-
-    labels = {
-      "openpolicyagent.org/policy" = "rego"
-    }
-  }
-
-  data = {
-    main = file(
-      "${path.module}/resources/policies/ingress_modsec_no_nginx_class.rego",
-    )
-  }
-
-  lifecycle {
-    ignore_changes = [metadata.0.annotations]
-  }
-}
-
-resource "kubernetes_config_map" "policy_ingress_nginx_class_modsec_snippet" {
-  metadata {
-    name      = "policy-ingress-nginx-class-modsec-snippet"
-    namespace = helm_release.open_policy_agent.namespace
-
-    labels = {
-      "openpolicyagent.org/policy" = "rego"
-    }
-  }
-
-  data = {
-    main = file(
-      "${path.module}/resources/policies/ingress_modsec_snippet_nginx_class.rego",
-    )
-  }
-
-  lifecycle {
-    ignore_changes = [metadata.0.annotations]
-  }
-}
-
-resource "kubernetes_config_map" "policy_ingress_no_nginx_class_modsec_snippet" {
-  metadata {
-    name      = "policy-ingress-no-nginx-class-modsec-snippet"
-    namespace = helm_release.open_policy_agent.namespace
-
-    labels = {
-      "openpolicyagent.org/policy" = "rego"
-    }
-  }
-
-  data = {
-    main = file(
-      "${path.module}/resources/policies/ingress_modsec_snippet_no_nginx_class.rego",
-    )
-  }
-
   lifecycle {
     ignore_changes = [metadata.0.annotations]
   }

--- a/resources/policies-test-cluster/valid_hostname_test.rego
+++ b/resources/policies-test-cluster/valid_hostname_test.rego
@@ -21,7 +21,7 @@ new_admission_review(op, newObject, oldObject) = {
 
 # generates a redacted Ingress spec
 new_ingress(host) = {
-  "apiVersion": "extensions/v1beta1",
+  "apiVersion": "networking.k8s.io/v1beta1",
   "kind": "Ingress",
   "spec": {
     "rules": [{ "host": host }]
@@ -38,4 +38,3 @@ test_valid_host_create_allowed {
   not denied
     with input as new_admission_review("CREATE", new_ingress("${cluster_domain_name}"), null)
 }
-valid_hostname_test.rego

--- a/resources/policies/ingress_clash_test.rego
+++ b/resources/policies/ingress_clash_test.rego
@@ -2,7 +2,7 @@ package cloud_platform.admission
 
 # generates a redacted Ingress spec
 new_ingress(namespace, name, host) = {
-  "apiVersion": "extensions/v1beta1",
+  "apiVersion": "networking.k8s.io/v1beta1",
   "kind": "Ingress",
   "metadata": {
     "name": name,

--- a/resources/policies/ingress_modsec_nginx_class.rego
+++ b/resources/policies/ingress_modsec_nginx_class.rego
@@ -1,0 +1,11 @@
+package cloud_platform.admission
+
+# This policy deny any ingress that have "kubernetes.io/ingress.class: nginx" annotation(using default ingress-controller) 
+# and use 'nginx.ingress.kubernetes.io/enable-modsecurity: "true"' annotation.
+
+deny[msg] {
+  input.request.kind.kind == "Ingress"
+  input.request.object.metadata.annotations["kubernetes.io/ingress.class"] == "nginx"
+  input.request.object.metadata.annotations["nginx.ingress.kubernetes.io/enable-modsecurity"] == "true"
+  msg := "Enabling mod-security is not allowed"
+}

--- a/resources/policies/ingress_modsec_no_nginx_class.rego
+++ b/resources/policies/ingress_modsec_no_nginx_class.rego
@@ -1,0 +1,11 @@
+package cloud_platform.admission
+
+# This policy deny any ingress that don't have "kubernetes.io/ingress.class" annotation(using default ingress-controller) 
+# and use 'nginx.ingress.kubernetes.io/enable-modsecurity: "true"' annotation.
+
+deny[msg] {
+  input.request.kind.kind == "Ingress"
+  not input.request.object.metadata.annotations["kubernetes.io/ingress.class"]
+  input.request.object.metadata.annotations["nginx.ingress.kubernetes.io/enable-modsecurity"] == "true"
+  msg := "Enabling mod-security is not allowed"
+}

--- a/resources/policies/ingress_modsec_snippet_nginx_class.rego
+++ b/resources/policies/ingress_modsec_snippet_nginx_class.rego
@@ -1,0 +1,11 @@
+package cloud_platform.admission
+
+# This policy deny any ingress that have "kubernetes.io/ingress.class: nginx" annotation(using default ingress-controller) 
+# and use "nginx.ingress.kubernetes.io/modsecurity-snippet" annotation.
+
+deny[msg] {
+  input.request.kind.kind == "Ingress"
+  input.request.object.metadata.annotations["kubernetes.io/ingress.class"] == "nginx"
+  input.request.object.metadata.annotations["nginx.ingress.kubernetes.io/modsecurity-snippet"]
+  msg := "modsecurity-snippet configuration is not allowed"
+}

--- a/resources/policies/ingress_modsec_snippet_no_nginx_class.rego
+++ b/resources/policies/ingress_modsec_snippet_no_nginx_class.rego
@@ -1,0 +1,11 @@
+package cloud_platform.admission
+
+# This policy deny any ingress that don't have any "kubernetes.io/ingress.class" annotation(using default ingress-controller) 
+# and use "nginx.ingress.kubernetes.io/modsecurity-snippet" annotation.
+
+deny[msg] {
+  input.request.kind.kind == "Ingress"
+  not input.request.object.metadata.annotations["kubernetes.io/ingress.class"]
+  input.request.object.metadata.annotations["nginx.ingress.kubernetes.io/modsecurity-snippet"]
+  msg := "modsecurity-snippet configuration is not allowed"
+}

--- a/resources/policies/ingress_modsec_test.rego
+++ b/resources/policies/ingress_modsec_test.rego
@@ -1,0 +1,75 @@
+package cloud_platform.admission
+
+ingress_with_modsec := {
+  "kind": "Ingress",
+  "metadata": {
+    "annotations": {
+      "nginx.ingress.kubernetes.io/enable-modsecurity": "true"
+    }
+  }
+}
+
+ingress_with_modsec_snippet := {
+  "kind": "Ingress",
+  "metadata": {
+    "annotations": {
+      "nginx.ingress.kubernetes.io/modsecurity-snippet": "whatever"
+    }
+  }
+}
+
+ingress_class_with_modsec := {
+  "kind": "Ingress",
+  "metadata": {
+    "annotations": {
+      "kubernetes.io/ingress.class": "nginx",
+      "nginx.ingress.kubernetes.io/enable-modsecurity": "true"
+    }
+  }
+}
+
+ingress_class_with_modsec_snippet := {
+  "kind": "Ingress",
+  "metadata": {
+    "annotations": {
+      "kubernetes.io/ingress.class": "nginx",
+      "nginx.ingress.kubernetes.io/modsecurity-snippet": "whatever"
+    }
+  }
+}
+
+diff_ingress_class_with_modsec := {
+  "kind": "Ingress",
+  "metadata": {
+    "annotations": {
+      "kubernetes.io/ingress.class": "some-other-ingress-class",
+      "nginx.ingress.kubernetes.io/enable-modsecurity": "true",
+      "nginx.ingress.kubernetes.io/modsecurity-snippet": "whatever"
+    }
+  }
+}
+
+test_deny_modsec_no_ingress_class {
+  denied
+    with input as new_admission_review("CREATE", ingress_with_modsec, null)
+}
+
+test_deny_modsec_snippet_no_ingress_class {
+  denied
+    with input as new_admission_review("CREATE", ingress_with_modsec_snippet, null)
+}
+
+test_deny_modsec {
+  denied
+    with input as new_admission_review("CREATE", ingress_class_with_modsec, null)
+}
+
+test_deny_modsec_snippet {
+  denied
+    with input as new_admission_review("CREATE", ingress_class_with_modsec_snippet, null)
+}
+
+test_not_deny_with_diff_ingress_class {
+  not denied
+    with input as new_admission_review("CREATE", diff_ingress_class_with_modsec, null)
+}

--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -15,7 +15,7 @@ admissionControllerFailurePolicy: Fail
 # operations are subject to OPA policy checks.
 admissionControllerRules:
   - operations: ["CREATE", "UPDATE"]
-    apiGroups: ["extensions"]
+    apiGroups: ["extensions", "networking.k8s.io"]
     apiVersions: ["*"]
     resources: ["ingresses"]
   - operations: ["CREATE", "UPDATE"]


### PR DESCRIPTION
This PR is to add policies to OPA to deny mod-sec on default ingress-controller.

Also updated admissionControllerRules to add "networking.k8s.io" for ingress resources
