### PR TITLE
Create Policy to check external-dns annotation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -79,6 +79,46 @@ resource "kubernetes_config_map" "policies_opa" {
   }
 }
 
+resource "kubernetes_config_map" "external_dns_weight" {
+  count = var.enable_external_dns_weight ? 1 : 0
+  metadata {
+    name      = "external-dns-weight"
+    namespace = helm_release.open_policy_agent.namespace
+
+    labels = {
+      "openpolicyagent.org/policy" = "rego"
+    }
+  }
+
+  data = {
+    main = file("${path.module}/resources/policies/external-dns-annotation/ingress_external_dns_no_weight.rego")
+  }
+
+  lifecycle {
+    ignore_changes = [metadata.0.annotations]
+  }
+}
+
+resource "kubernetes_config_map" "external_dns_identifier" {
+  count = var.enable_external_dns_weight ? 1 : 0
+  metadata {
+    name      = "external-dns-identifier"
+    namespace = helm_release.open_policy_agent.namespace
+
+    labels = {
+      "openpolicyagent.org/policy" = "rego"
+    }
+  }
+
+  data = {
+    main = file("${path.module}/resources/policies/external-dns-annotation/ingress_external_dns_no_identifier.rego")
+  }
+
+  lifecycle {
+    ignore_changes = [metadata.0.annotations]
+  }
+}
+
 resource "kubernetes_config_map" "valid_host" {
   count = var.enable_invalid_hostname_policy ? 1 : 0
   metadata {

--- a/resources/policies/external-dns-annotation/ingress_external_dns_no_identifier.rego
+++ b/resources/policies/external-dns-annotation/ingress_external_dns_no_identifier.rego
@@ -1,0 +1,11 @@
+package cloud_platform.admission
+
+# This policy deny any ingress that don't have annotation "external-dns.alpha.kubernetes.io/set-identifier"
+# or not use 'cloud-platform.justice.gov.uk/ignore-external-dns-weight: "true"' annotation to ignore about check.
+
+deny[msg] {
+  input.request.kind.kind == "Ingress"
+  not input.request.object.metadata.annotations["external-dns.alpha.kubernetes.io/set-identifier"]
+  not input.request.object.metadata.annotations["cloud-platform.justice.gov.uk/ignore-external-dns-weight"] == "true"
+  msg := "Please add external-dns annotation for ingress"
+}

--- a/resources/policies/external-dns-annotation/ingress_external_dns_no_weight.rego
+++ b/resources/policies/external-dns-annotation/ingress_external_dns_no_weight.rego
@@ -1,0 +1,11 @@
+package cloud_platform.admission
+
+# This policy deny any ingress that don't have annotation "external-dns.alpha.kubernetes.io/aws-weight"
+# or not use 'cloud-platform.justice.gov.uk/ignore-external-dns-weight: "true"' annotation to ignore about check.
+
+deny[msg] {
+  input.request.kind.kind == "Ingress"
+  not input.request.object.metadata.annotations["external-dns.alpha.kubernetes.io/aws-weight"]
+  not input.request.object.metadata.annotations["cloud-platform.justice.gov.uk/ignore-external-dns-weight"] == "true"
+  msg := "Please add external-dns annotation for ingress"
+}

--- a/resources/policies/external-dns-annotation/ingress_external_dns_test.rego
+++ b/resources/policies/external-dns-annotation/ingress_external_dns_test.rego
@@ -1,0 +1,100 @@
+package cloud_platform.admission
+
+ingress_with_external_dns_weight_annotation := {
+  "kind": "Ingress",
+  "metadata": {
+    "annotations": {
+      "external-dns.alpha.kubernetes.io/aws-weight": "100"
+    }
+  }
+}
+
+ingress_with_external_dns_identifier_annotation := {
+  "kind": "Ingress",
+  "metadata": {
+    "annotations": {
+      "external-dns.alpha.kubernetes.io/set-identifier": "whatever"
+    }
+  }
+}
+
+ingress_with_false_ignore_annotation := {
+  "kind": "Ingress",
+  "metadata": {
+    "annotations": {
+      "cloud-platform.justice.gov.uk/ignore-external-dns-weight": "false"
+    }
+  }
+}
+
+ingress_with_no_external_dns_and_ignore_annotation := {
+  "kind": "Ingress",
+  "metadata": {
+    "annotations": {}
+  }
+}
+
+ingress_with_external_dns_and_ignore_annotation := {
+  "kind": "Ingress",
+  "metadata": {
+    "annotations": {
+      "external-dns.alpha.kubernetes.io/aws-weight": "100",
+      "external-dns.alpha.kubernetes.io/set-identifier": "whatever",
+      "cloud-platform.justice.gov.uk/ignore-external-dns-weight": "true"
+    }
+  }
+}
+
+ingress_with_ignore_annotation := {
+  "kind": "Ingress",
+  "metadata": {
+    "annotations": {
+      "cloud-platform.justice.gov.uk/ignore-external-dns-weight": "true"
+    }
+  }
+}
+
+ingress_with_both_external_dns_annotation := {
+  "kind": "Ingress",
+  "metadata": {
+    "annotations": {
+      "external-dns.alpha.kubernetes.io/aws-weight": "100",
+      "external-dns.alpha.kubernetes.io/set-identifier": "whatever"
+    }
+  }
+}
+
+test_deny_ingress_with_external_dns_weight_annotation {
+  denied
+    with input as new_admission_review("CREATE", ingress_with_external_dns_weight_annotation, null)
+}
+
+test_deny_ingress_with_external_dns_identifier_annotation {
+  denied
+    with input as new_admission_review("CREATE", ingress_with_external_dns_identifier_annotation, null)
+}
+
+test_deny_ingress_with_false_ignore_annotation {
+  denied
+    with input as new_admission_review("CREATE", ingress_with_false_ignore_annotation, null)
+}
+
+test_deny_ingress_with_no_external_dns_and_ignore_annotation {
+  denied
+    with input as new_admission_review("CREATE", ingress_with_no_external_dns_and_ignore_annotation, null)
+}
+
+test_not_deny_ingress_with_external_dns_and_ignore_annotation {
+  not denied
+    with input as new_admission_review("CREATE", ingress_with_external_dns_and_ignore_annotation, null)
+}
+
+test_not_deny_ingress_with_ignore_annotation {
+  not denied
+    with input as new_admission_review("CREATE", ingress_with_ignore_annotation, null)
+}
+
+test_not_deny_ingress_with_both_external_dns_annotation {
+  not denied
+    with input as new_admission_review("CREATE", ingress_with_both_external_dns_annotation, null)
+}

--- a/resources/policies/ingress_clash_test.rego
+++ b/resources/policies/ingress_clash_test.rego
@@ -6,7 +6,11 @@ new_ingress(namespace, name, host) = {
   "kind": "Ingress",
   "metadata": {
     "name": name,
-    "namespace": namespace
+    "namespace": namespace,
+    "annotations": {
+      "external-dns.alpha.kubernetes.io/aws-weight": "100",
+      "external-dns.alpha.kubernetes.io/set-identifier": "whatever",
+    }
   },
   "spec": {
     "rules": [{ "host": host }]

--- a/resources/policies/ingress_modsec_test.rego
+++ b/resources/policies/ingress_modsec_test.rego
@@ -4,7 +4,9 @@ ingress_with_modsec := {
   "kind": "Ingress",
   "metadata": {
     "annotations": {
-      "nginx.ingress.kubernetes.io/enable-modsecurity": "true"
+      "nginx.ingress.kubernetes.io/enable-modsecurity": "true",
+      "external-dns.alpha.kubernetes.io/aws-weight": "100",
+      "external-dns.alpha.kubernetes.io/set-identifier": "whatever",
     }
   }
 }
@@ -13,7 +15,9 @@ ingress_with_modsec_snippet := {
   "kind": "Ingress",
   "metadata": {
     "annotations": {
-      "nginx.ingress.kubernetes.io/modsecurity-snippet": "whatever"
+      "nginx.ingress.kubernetes.io/modsecurity-snippet": "whatever",
+      "external-dns.alpha.kubernetes.io/aws-weight": "100",
+      "external-dns.alpha.kubernetes.io/set-identifier": "whatever",
     }
   }
 }
@@ -23,7 +27,9 @@ ingress_class_with_modsec := {
   "metadata": {
     "annotations": {
       "kubernetes.io/ingress.class": "nginx",
-      "nginx.ingress.kubernetes.io/enable-modsecurity": "true"
+      "nginx.ingress.kubernetes.io/enable-modsecurity": "true",
+      "external-dns.alpha.kubernetes.io/aws-weight": "100",
+      "external-dns.alpha.kubernetes.io/set-identifier": "whatever",
     }
   }
 }
@@ -33,7 +39,9 @@ ingress_class_with_modsec_snippet := {
   "metadata": {
     "annotations": {
       "kubernetes.io/ingress.class": "nginx",
-      "nginx.ingress.kubernetes.io/modsecurity-snippet": "whatever"
+      "nginx.ingress.kubernetes.io/modsecurity-snippet": "whatever",
+      "external-dns.alpha.kubernetes.io/aws-weight": "100",
+      "external-dns.alpha.kubernetes.io/set-identifier": "whatever",
     }
   }
 }
@@ -44,7 +52,9 @@ diff_ingress_class_with_modsec := {
     "annotations": {
       "kubernetes.io/ingress.class": "some-other-ingress-class",
       "nginx.ingress.kubernetes.io/enable-modsecurity": "true",
-      "nginx.ingress.kubernetes.io/modsecurity-snippet": "whatever"
+      "nginx.ingress.kubernetes.io/modsecurity-snippet": "whatever",
+      "external-dns.alpha.kubernetes.io/aws-weight": "100",
+      "external-dns.alpha.kubernetes.io/set-identifier": "whatever",
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -3,7 +3,14 @@ variable "cluster_domain_name" {
 }
 
 variable "enable_invalid_hostname_policy" {
-  description = "Enable wheter to have the OPA policy of invalid hostname enabled"
+  description = "Enable whether to have the OPA policy of invalid hostname enabled"
+  default     = false
+  type        = bool
+}
+
+
+variable "enable_external_dns_weight" {
+  description = "Enable OPA policy to deny ingress creation with out external_dns annotation "
   default     = false
   type        = bool
 }


### PR DESCRIPTION
 - This is to deny ingress creation without external_dns annotation.
 -  Terraform count condition to enable this policy, as only get applied to live-eks.
 -  Create tests for external-dns annotation check
 -  Fix existing tests

 This is related to:
 https://github.com/ministryofjustice/cloud-platform/issues/3008