### PR TITLE
Add external-dns identifier validation and refactor configmaps generation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -47,7 +47,6 @@ resource "null_resource" "kube_system_ns_label" {
 }
 
 resource "kubernetes_config_map" "policies_opa" {
-
   for_each = {
     policy-default                               = "main",
     policy-cloud-platform-admission              = "cloud_platform_admission",
@@ -80,8 +79,6 @@ resource "kubernetes_config_map" "policies_opa" {
 }
 
 resource "kubernetes_config_map" "external_dns_policies" {
-  # count = var.enable_external_dns_weight ? 1 : 0
-
   for_each = var.enable_external_dns_weight ? {
     external-dns-identifier        = "ingress_external_dns_no_identifier",
     external-dns-weight            = "ingress_external_dns_no_weight",

--- a/resources/policies/external-dns-annotation/ingress_external_dns_identifier_format.rego
+++ b/resources/policies/external-dns-annotation/ingress_external_dns_identifier_format.rego
@@ -1,0 +1,11 @@
+package cloud_platform.admission
+
+# This policy deny any ingress that don't have annotation "external-dns.alpha.kubernetes.io/set-identifier"
+# or not use 'cloud-platform.justice.gov.uk/ignore-external-dns-weight: "true"' annotation to ignore about check.
+
+deny[msg] {
+  input.request.kind.kind == "Ingress"
+  not input.request.object.metadata.annotations["external-dns.alpha.kubernetes.io/set-identifier"] == concat("-", [input.request.object.metadata.name, input.request.object.metadata.namespace, ${cluster_color}])
+  not input.request.object.metadata.annotations["cloud-platform.justice.gov.uk/ignore-external-dns-weight"] == "true"
+  msg := "Please add valid external-dns identifier for ingress, remember: <ingress-name>-<ns>-<color>. Color is either blue or green"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,11 @@ variable "enable_invalid_hostname_policy" {
   type        = bool
 }
 
+variable "cluster_color" {
+  description = "Cluster color (blue/green). This variable is effective only when enable_external_dns_weight is set"
+  default     = "blue"
+  type        = string
+}
 
 variable "enable_external_dns_weight" {
   description = "Enable OPA policy to deny ingress creation with out external_dns annotation "


### PR DESCRIPTION
- Created new rego file with new validations: `<ingress-name>-<ns>-<color>`. Where color is an argument for the OPA module.
- Refactor terraform code (using `for_each`) to generate configmaps for external DNS annotations.