### PR TITLE
Upgrade OPA to use the latest image

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -58,7 +58,6 @@ resource "kubernetes_config_map" "policies_opa" {
     policy-ingress-no-nginx-class-modsec         = "ingress_modsec_no_nginx_class",
     policy-ingress-nginx-class-modsec-snippet    = "ingress_modsec_snippet_nginx_class",
     policy-ingress-no-nginx-class-modsec-snippet = "ingress_modsec_snippet_no_nginx_class",
-    policy-snippet-allowlist                     = "snippet_allowlist",
   }
 
   metadata {


### PR DESCRIPTION
imageTag: 0.33.1 for OPA
imageTag: "0.13" for kube-mgmt