### PR TITLE
Update valid_host policy to enable integration test zone

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -120,7 +120,7 @@ resource "kubernetes_config_map" "valid_host" {
 
   data = {
     main = templatefile("${path.module}/resources/policies-test-cluster/valid_hostname.rego", {
-      valid_domain_names = "*.${var.cluster_domain_name}, *.${var.integration_test_zone}"
+      valid_domain_names = "*.${var.cluster_domain_name},*.${var.integration_test_zone}"
     })
   }
 

--- a/main.tf
+++ b/main.tf
@@ -105,6 +105,8 @@ resource "kubernetes_config_map" "external_dns_policies" {
   }
 }
 
+# Policy for test clusters, to use only cluster domain and integration test domain as valid host names
+
 resource "kubernetes_config_map" "valid_host" {
   count = var.enable_invalid_hostname_policy ? 1 : 0
 
@@ -118,7 +120,7 @@ resource "kubernetes_config_map" "valid_host" {
 
   data = {
     main = templatefile("${path.module}/resources/policies-test-cluster/valid_hostname.rego", {
-      cluster_domain_name = "*.${var.cluster_domain_name}"
+      valid_domain_names = "*.${var.cluster_domain_name}, *.${var.integration_test_zone}"
     })
   }
 

--- a/resources/policies-test-cluster/valid_hostname.rego
+++ b/resources/policies-test-cluster/valid_hostname.rego
@@ -9,7 +9,7 @@ deny[msg] {
   msg := sprintf("invalid ingress host %q", [host])
 }
 valid_ingress_hosts = {host |
-  whitelist := "${cluster_domain_name}"
+  whitelist := "${valid_domain_names}"
   hosts := split(whitelist, ",")
   host := hosts[_]
 }

--- a/resources/policies-test-cluster/valid_hostname_test.rego
+++ b/resources/policies-test-cluster/valid_hostname_test.rego
@@ -30,11 +30,11 @@ new_ingress(host) = {
 
 test_invalid_host_create_notallowed {
   denied
-    with input as new_admission_review("CREATE", new_ingress("${not.cluster_domain_name}"), null)
+    with input as new_admission_review("CREATE", new_ingress("${not.valid_domain_names}"), null)
 }
 
 
 test_valid_host_create_allowed {
   not denied
-    with input as new_admission_review("CREATE", new_ingress("${cluster_domain_name}"), null)
+    with input as new_admission_review("CREATE", new_ingress("${valid_domain_names}"), null)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -22,4 +22,5 @@ variable "enable_external_dns_weight" {
 
 variable "integration_test_zone" {
   description = "Integration test zone, for test clusters to use it for valid ingress policy"
+  default     = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -19,3 +19,7 @@ variable "enable_external_dns_weight" {
   default     = false
   type        = bool
 }
+
+variable "integration_test_zone" {
+  description = "Integration test zone, for test clusters to use it for valid ingress policy"
+}


### PR DESCRIPTION
This will enable test clusters to use integration test zone names, as valid hosts.