### PR TITLE
Domain label length update

### DIFF
--- a/resources/policies/ingress_hostname_length.rego
+++ b/resources/policies/ingress_hostname_length.rego
@@ -10,6 +10,8 @@ import data.kubernetes.ingresses
 # Each label can be up to 63 bytes long. The total length of a domain name cannot exceed 255 bytes, including the dots. Amazon Route 53 supports any valid domain name.
 #
 # Total domain name lengths do not require an OPA policy as the Ingress annotations have an enforced 253 character limit.
+#
+# NOTE: as of v0.12 external-dns prepends "cname-" (6 chars) to first domain label, so we need to set label length limit to 57 to counter post admission control DNS record failures.
 
 # Check labels length
 deny[msg] {
@@ -17,6 +19,6 @@ deny[msg] {
 	domain := input.request.object.spec.rules[_].host
 	labels := split(domain, ".")
     some i
-    count(labels[i]) > 63
-	msg := sprintf("\nLabel '%v' in hostname: '%v' exceeds permitted length of 63 characters", [labels[i], domain])
+    count(labels[i]) > 57
+	msg := sprintf("\nLabel '%v' in hostname: '%v' exceeds permitted length of 57 characters", [labels[i], domain])
 }

--- a/resources/policies/ingress_hostname_length_test.rego
+++ b/resources/policies/ingress_hostname_length_test.rego
@@ -19,7 +19,7 @@ test_allow_create_ingress_hostname_label_length {
 
 test_allow_create_ingress_hostname_at_max_label_length {
   not denied
-    with input as new_admission_review("CREATE", ingress_test("this-label-is-total-sixty-three-characters-length-limit-exactly.apps.live.cloud-platform.service.justice.gov.uk"), null)
+    with input as new_admission_review("CREATE", ingress_test("label-is-total-fiftyseven-characters-length-limit-exactly.apps.live.cloud-platform.service.justice.gov.uk"), null)
 }
 
 test_allow_update_ingress_hostname_label_length {


### PR DESCRIPTION
This PR is to reduce permitted character length for a DNS domain label to 57 characters to mitigate external-dns TXT record prefix issue